### PR TITLE
Update mnist_spiking_cnn.ipynb

### DIFF
--- a/docs/examples/keras/mnist_spiking_cnn.ipynb
+++ b/docs/examples/keras/mnist_spiking_cnn.ipynb
@@ -123,7 +123,7 @@
     "    kmodel.add(Activation('softmax'))\n",
     "\n",
     "    # compile and fit Keras model\n",
-    "    optimizer = keras.optimizers.Nadam()\n",
+    "    optimizer = "nadam"\n",
     "    kmodel.compile(loss='categorical_crossentropy',\n",
     "                   optimizer=optimizer,\n",
     "                   metrics=['accuracy'])\n",


### PR DESCRIPTION
Optimizer in keras is now called by string for example: "nadam" instead of keras.optimizers.nadam().